### PR TITLE
Patch to load partition with only nulls as a category

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,12 @@
 Changelog
 =========
 
-Plateau 4.1.2 (2022-10-24)
+Plateau 4.1.3 (2022-10-24)
+==========================
+
+* Patch to load partition with only nulls as categorical (#55)
+
+Plateau 4.1.2 (2022-10-20)
 ==========================
 
 * Removed upper-bound pin in pyarrow version dependency
@@ -20,7 +25,6 @@ Plateau 4.1.0 (2022-10-19)
 * Support for ``dask>=2022.4.2``
 * Support Python 3.8-3.10
 * Replaced ``simplekv`` and ``storefact`` usages with ``minimalkv``
-* Patch to load partition with only nulls as categorical (#55).
 
 Plateau 4.0.4 (2022-03-17)
 ==========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-Plateau 4.1.0 (2022-09-??)
+Plateau 4.1.0 (2022-10-XX)
 ==========================
 
 * Support for ``pyarrow`` 5, 6, 7, 8, 9
@@ -10,6 +10,7 @@ Plateau 4.1.0 (2022-09-??)
 * Support for ``dask>=2022.4.2``
 * Support Python 3.8-3.10
 * Replaced ``simplekv`` and ``storefact`` usages with ``minimalkv``
+* Patch to load partition with only nulls as categorical (#55).
 
 Plateau 4.0.4 (2022-03-17)
 ==========================

--- a/plateau/serialization/_parquet.py
+++ b/plateau/serialization/_parquet.py
@@ -289,8 +289,11 @@ class ParquetSerializer(DataFrameSerializer):
 
         table = _reset_dictionary_columns(table, exclude=categories)
         df = table.to_pandas(date_as_object=date_as_object)
-        for col in categories or []:
-            df[col] = df[col].astype("category")
+
+        if categories:
+            for col in categories:
+                df[col] = df[col].astype("category")
+
         df.columns = df.columns.map(ensure_unicode_string_type)
         if predicates:
             df = filter_df_from_predicates(

--- a/plateau/serialization/_parquet.py
+++ b/plateau/serialization/_parquet.py
@@ -288,11 +288,14 @@ class ParquetSerializer(DataFrameSerializer):
                 )
 
         table = _reset_dictionary_columns(table, exclude=categories)
+
         df = table.to_pandas(date_as_object=date_as_object)
 
+        # XXX: Patch until Pyarrow bug is resolved: https://issues.apache.org/jira/browse/ARROW-18099?filter=-2
         if categories:
             for col in categories:
-                df[col] = df[col].astype("category")
+                if col in df:
+                    df[col] = df[col].astype("category")
 
         df.columns = df.columns.map(ensure_unicode_string_type)
         if predicates:

--- a/plateau/serialization/_parquet.py
+++ b/plateau/serialization/_parquet.py
@@ -289,8 +289,8 @@ class ParquetSerializer(DataFrameSerializer):
 
         table = _reset_dictionary_columns(table, exclude=categories)
         df = table.to_pandas(date_as_object=date_as_object)
-        for col in categories:
-            df[col] = df[col].astype('category')
+        for col in categories or []:
+            df[col] = df[col].astype("category")
         df.columns = df.columns.map(ensure_unicode_string_type)
         if predicates:
             df = filter_df_from_predicates(

--- a/plateau/serialization/_parquet.py
+++ b/plateau/serialization/_parquet.py
@@ -288,7 +288,9 @@ class ParquetSerializer(DataFrameSerializer):
                 )
 
         table = _reset_dictionary_columns(table, exclude=categories)
-        df = table.to_pandas(categories=categories, date_as_object=date_as_object)
+        df = table.to_pandas(date_as_object=date_as_object)
+        for col in categories:
+            df[col] = df[col].astype('category')
         df.columns = df.columns.map(ensure_unicode_string_type)
         if predicates:
             df = filter_df_from_predicates(

--- a/tests/serialization/test_parquet.py
+++ b/tests/serialization/test_parquet.py
@@ -429,7 +429,20 @@ def test_read_categorical(store):
     assert df.dtypes["col"] == pd.CategoricalDtype(["a"], ordered=False)
 
 
-def test_read_categorical_empty(store):
+def test_read_empty_categorical(store):
+    df = pd.DataFrame({"col": [None]}).astype({"col": "category"})
+
+    serialiser = ParquetSerializer()
+    key = serialiser.store(store, "prefix", df)
+
+    df = serialiser.restore_dataframe(store, key)
+    assert df.dtypes["col"] == "O"
+
+    df = serialiser.restore_dataframe(store, key, categories=["col"])
+    assert df.dtypes["col"] == pd.CategoricalDtype([], ordered=False)
+
+
+def test_read_categorical_empty_dataframe(store):
 
     df = pd.DataFrame({"col": ["a"]}).astype({"col": "category"}).iloc[:0]
     serialiser = ParquetSerializer()


### PR DESCRIPTION
# Description:

There is buggy behavior described in issue #55. Essentially, this is a PR which makes loading a partition with only nulls as a categorical possible.

- [X] Closes #55
- [x] Changelog entry
