### PR TITLE
Remove pyarrow upper-bound version pin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Plateau 4.1.2 (2022-10-20)
+==========================
+
+* Removed upper-bound pin in pyarrow version dependency
+
 Plateau 4.1.1 (2022-10-19)
 ==========================
 

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -9,7 +9,7 @@ dependencies:
   # Currently dask and numpy==1.16.0 clash
   - numpy!=1.15.0,!=1.16.0
   - pandas>=0.23.0, !=1.0.0
-  - pyarrow>=0.17.1,!=1.0.0, <10
+  - pyarrow>=0.17.1,!=1.0.0
   - simplejson
   - minimalkv
   - toolz

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   # TODO: add support for numpy>=1.23
   - numpy!=1.15.0,!=1.16.0
   - pandas>=0.23.0, !=1.0.0
-  - pyarrow>=0.17.1,!=1.0.0, <10
+  - pyarrow>=0.17.1,!=1.0.0
   - simplejson
   - minimalkv>=1.4.2
   - toolz

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     # Currently dask and numpy==1.16.0 clash
     numpy!=1.15.0,!=1.16.0
     pandas>=0.23.0, !=1.0.0
-    pyarrow>=0.17.1,!=1.0.0,<7
+    pyarrow>=0.17.1,!=1.0.0
     simplejson
     minimalkv>=1.4.2
     toolz


### PR DESCRIPTION
# Description:

Pyarrow was set to be `<7` and `<10` in some places in this repository. This upper-bound pin conflicted with the latest version of pyarrow.


- [ ] Closes #xxxx
- [X] Changelog entry
