### PR TITLE
Do not test pickle in shuffle

### DIFF
--- a/tests/io/dask/dataframe/test_read.py
+++ b/tests/io/dask/dataframe/test_read.py
@@ -161,8 +161,10 @@ def test_reconstruct_dask_index(store_factory, index_type, monkeypatch):
     assert len(ddf.divisions) == 5
     assert ddf.divisions == (1, 2, 3, 4, 4)
 
-    assert_dask_eq(ddf_expected, ddf)
-    assert_dask_eq(ddf_expected_simple, ddf, check_divisions=False)
+    assert_dask_eq(ddf_expected, ddf, scheduler="distributed")
+    assert_dask_eq(
+        ddf_expected_simple, ddf, check_divisions=False, scheduler="distributed"
+    )
 
     assert_frame_equal(ddf_expected.compute(), ddf.compute())
     assert_frame_equal(ddf_expected_simple.compute(), ddf.compute())

--- a/tests/io/dask/dataframe/test_shuffle.py
+++ b/tests/io/dask/dataframe/test_shuffle.py
@@ -1,5 +1,3 @@
-import pickle
-
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
@@ -159,9 +157,6 @@ def test_update_shuffle_buckets(
         sort_partitions_by="sorted_column",
         partition_on=["primary"],
     )
-
-    s = pickle.dumps(dataset_comp, pickle.HIGHEST_PROTOCOL)
-    dataset_comp = pickle.loads(s)
 
     dataset = dataset_comp.compute()
     dataset = dataset.load_all_indices(store_factory())


### PR DESCRIPTION
Pickling graphs is not the best idea. The pickle protocol is not properly implemented for many graph subtypes sometimes causing annotation loss or other things.

This will change with https://github.com/dask/distributed/pull/7564 which is expected to go in before the next release. Still, I don't think it's necessary to test this here.

If somebody feels strongly about this I can add a dask version guard for this assertion