### PR TITLE
Remove usage of pkg_resources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Plateau 4.1.5 (2023-03-13)
 
 * Enable dask column projection.
 * Test pyarrow 11
+* Remove usage of ``pkg_resources``.
 
 Plateau 4.1.4 (2022-12-14)
 ==========================

--- a/plateau/__init__.py
+++ b/plateau/__init__.py
@@ -1,6 +1,6 @@
-import pkg_resources
+import importlib.metadata
 
 try:
-    __version__ = pkg_resources.get_distribution(__name__).version
+    __version__ = importlib.metadata.version(__name__)
 except Exception:  # pragma: no cover
     __version__ = "unknown"

--- a/plateau/serialization/__init__.py
+++ b/plateau/serialization/__init__.py
@@ -1,5 +1,3 @@
-import pkg_resources
-
 from ._csv import CsvSerializer
 from ._generic import (
     ConjunctionType,
@@ -15,12 +13,6 @@ from ._generic import (
     filter_predicates_by_column,
 )
 from ._parquet import ParquetSerializer
-
-try:
-    __version__ = pkg_resources.get_distribution(__name__).version
-except:  # noqa
-    __version__ = "unknown"
-
 
 DataFrameSerializer.register_serializer(".csv.gz", CsvSerializer)
 DataFrameSerializer.register_serializer(".csv", CsvSerializer)


### PR DESCRIPTION
# Description:

It's deprecated and `importlib.metadata` is available since 3.8.

- [ ] Closes #xxxx
- [x] Changelog entry
