### PR TITLE
Support for dask 2023.9.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Plateau 4.2.0 (unreleased)
 * Test pyarrow 12 and 13
 * Prevent dask from casting all object dtypes to strings
 * Remove tests for pyarrow<=3 as they fail with pandas>=2
+* Adds support for dask 2023.9.2
 
 Plateau 4.1.5 (2023-03-14)
 ==========================

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.8
-  - dask<2023.9.2
+  - dask
   - decorator
   - msgpack-python>=0.5.2
   # Currently dask and numpy==1.16.0 clash

--- a/environment.yml
+++ b/environment.yml
@@ -3,8 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  # TODO: Investigate issue with dask 2023.9.2
-  - dask!=2021.5.1,!=2021.6.0,<2023.9.2  # gh475 - 2021.5.1 and 2021.6.0 broke ci, omit those versions
+  - dask!=2021.5.1,!=2021.6.0 # gh475 - 2021.5.1 and 2021.6.0 broke ci, omit those versions
   - decorator
   - msgpack-python>=0.5.2
   # Currently dask and numpy==1.16.0 clash

--- a/plateau/io/dask/dataframe.py
+++ b/plateau/io/dask/dataframe.py
@@ -332,7 +332,9 @@ def store_dataset_from_ddf(
     if not overwrite:
         raise_if_dataset_exists(dataset_uuid=dataset_uuid, store=store)
 
-    with dask.config.set({"dataframe.convert-string": False}):
+    with dask.config.set(
+        {"dataframe.convert-string": False, "dataframe.shuffle.method": "tasks"}
+    ):
         mp_ser = _write_dataframe_partitions(
             ddf=ddf,
             store=ds_factory.store_factory,
@@ -476,7 +478,9 @@ def update_dataset_from_ddf(
     inferred_indices = _ensure_compatible_indices(ds_factory, secondary_indices)
     del secondary_indices
 
-    with dask.config.set({"dataframe.convert-string": False}):
+    with dask.config.set(
+        {"dataframe.convert-string": False, "dataframe.shuffle.method": "tasks"}
+    ):
         mp_ser = _write_dataframe_partitions(
             ddf=ddf,
             store=ds_factory.store_factory if ds_factory else store,
@@ -659,7 +663,9 @@ def hash_dataset(
         columns=columns,
         dates_as_object=True,
     )
-    with dask.config.set({"dataframe.convert-string": False}):
+    with dask.config.set(
+        {"dataframe.convert-string": False, "dataframe.shuffle.method": "tasks"}
+    ):
         if not group_key:
             return ddf.map_partitions(_hash_partition, meta="uint64").astype("uint64")
         else:

--- a/plateau/io/dask/delayed.py
+++ b/plateau/io/dask/delayed.py
@@ -95,7 +95,9 @@ def delete_dataset__delayed(dataset_uuid=None, store=None, factory=None):
         dataset_uuid=dataset_factory.dataset_uuid,
     )
 
-    return delayed(_delete_tl_metadata)(dataset_factory, mps, gc, delayed_dataset_uuid)
+    return delayed(_delete_tl_metadata)(
+        dataset_factory, list(mps), gc, delayed_dataset_uuid
+    )
 
 
 @default_docs
@@ -313,7 +315,7 @@ def update_dataset_from_delayed(
     )
 
     return dask.delayed(update_dataset_from_partitions)(
-        mps,
+        list(mps),
         store_factory=store,
         dataset_uuid=dataset_uuid,
         ds_factory=ds_factory,
@@ -376,7 +378,7 @@ def store_delayed_as_dataset(
     )
 
     return delayed(store_dataset_from_partitions)(
-        mps,
+        list(mps),
         dataset_uuid=dataset_uuid,
         store=store,
         dataset_metadata=metadata,

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ classifiers =
 [options]
 include_package_data = true
 install_requires =
-    dask[dataframe]!=2021.5.1,!=2021.6.0,<2023.9.2  # gh475 - 2021.5.1 and 2021.6.0 broke ci, omit those versions
+    dask[dataframe]!=2021.5.1,!=2021.6.0 # gh475 - 2021.5.1 and 2021.6.0 broke ci, omit those versions
     decorator
     msgpack>=0.5.2
     # Currently dask and numpy==1.16.0 clash

--- a/tests/io/dask/dataframe/test_read.py
+++ b/tests/io/dask/dataframe/test_read.py
@@ -119,12 +119,13 @@ def test_reconstruct_dask_index(store_factory, index_type, monkeypatch):
     df2 = pd.DataFrame({colA: [3, 4], colB: ["x", "y"]})
     df_chunks = np.array_split(pd.concat([df1, df2]).reset_index(drop=True), 4)
     df_delayed = [dask.delayed(c) for c in df_chunks]
-    ddf_expected = dd.from_delayed(df_delayed).set_index(
-        colA, divisions=[1, 2, 3, 4, 4]
-    )
-    ddf_expected_simple = dd.from_pandas(
-        pd.concat([df1, df2]), npartitions=2
-    ).set_index(colA)
+    with dask.config.set({"dataframe.shuffle.method": "tasks"}):
+        ddf_expected = dd.from_delayed(df_delayed).set_index(
+            colA, divisions=[1, 2, 3, 4, 4]
+        )
+        ddf_expected_simple = dd.from_pandas(
+            pd.concat([df1, df2]), npartitions=2
+        ).set_index(colA)
 
     if index_type == "secondary":
         secondary_indices = colA


### PR DESCRIPTION
Adds support for dask 2023.9.2

Previously, dask would wrap all iterators passed to `delayed()` with `list()` or `tuple()`. As of 2023.9.2, this is no longer the case, therefore, we wrap map objects with `list()` before passing them into `delayed()`. Also, we now explicitly set the dask dataframe shuffle method - prior to 2023.9.2 this would be set for us depending on the `pyarrow` version, but this is no longer the case.

The dask tests are now passing again. I also tested the changes by pip installing this branch into `quantcore.thek` and running the test suite, which also passed.

- [x] Closes #95
- [x] Changelog entry
