### PR TITLE
Migrate to setup-micromamba from provision-with-micromamba

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,10 +114,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Conda env
-        uses: mamba-org/provision-with-micromamba@3c96c0c27676490c63c18bc81f5c51895ac3e0e6
+        uses: mamba-org/setup-micromamba@2b72821d5ad7f6da3c003a3684ce341bf187b46f
         with:
-          cache-env: true
-          extra-specs: |
+          environment-file: environment.yml
+          cache-environment: true
+          create-args: >-
             python=${{ matrix.PYTHON_VERSION }}
       - name: Install Pyarrow (non-nightly)
         # Don't pin python as older versions of pyarrow require older versions of python

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -20,11 +20,10 @@ jobs:
         with:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Set up Conda env
-        uses: mamba-org/provision-with-micromamba@3c96c0c27676490c63c18bc81f5c51895ac3e0e6
+        uses: mamba-org/setup-micromamba@2b72821d5ad7f6da3c003a3684ce341bf187b46f
         with:
-          environment-file: false
           environment-name: pre-commit
-          extra-specs: |
+          create-args: >-
             -c
             conda-forge
             pre-commit


### PR DESCRIPTION
The [`provision-with-micromamba`](https://github.com/mamba-org/provision-with-micromamba) GitHub action is deprecated. Migrating over to [`setup-micromamba`](https://github.com/mamba-org/setup-micromamba).