### PR TITLE
Remove pandas<2.1.0 pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,6 @@ jobs:
             python=${{ matrix.PYTHON_VERSION }}
       - name: Install Pyarrow (non-nightly)
         # Don't pin python as older versions of pyarrow require older versions of python
-        # Pin asv so it doesn't get updated before the benchmarks are run
         run: micromamba install -y --no-py-pin pyarrow==${{ matrix.pyarrow }}
         if: matrix.pyarrow != 'nightly' && matrix.pandas == ''
       - name: Install Pyarrow (nightly)
@@ -137,7 +136,7 @@ jobs:
       - name: Pip Install NumFOCUS nightly
         # NumFOCUS nightly wheels, contains numpy and pandas
         # TODO(gh-45): Re-add numpy
-        run: python -m pip install --pre --upgrade --timeout=60 --extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple
+        run: python -m pip install --pre --upgrade --timeout=60 --extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple pandas
         if: matrix.numfocus_nightly
       - name: Install repository
         run: python -m pip install --no-build-isolation --no-deps --disable-pip-version-check -e .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Pip Install NumFOCUS nightly
         # NumFOCUS nightly wheels, contains numpy and pandas
         # TODO(gh-45): Re-add numpy
-        run: python -m pip install --pre --upgrade --timeout=60 --extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple pandas
+        run: python -m pip install --pre --upgrade --timeout=60 --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ pandas
         if: matrix.numfocus_nightly
       - name: Install repository
         run: python -m pip install --no-build-isolation --no-deps --disable-pip-version-check -e .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Install Pyarrow (non-nightly)
         # Don't pin python as older versions of pyarrow require older versions of python
         # Pin asv so it doesn't get updated before the benchmarks are run
-        run: micromamba install -y --no-py-pin pyarrow==${{ matrix.pyarrow }} "pandas<2.1.0"
+        run: micromamba install -y --no-py-pin pyarrow==${{ matrix.pyarrow }}
         if: matrix.pyarrow != 'nightly' && matrix.pandas == ''
       - name: Install Pyarrow (nightly)
         # Install both arrow-cpp and pyarrow to make sure that we have the
@@ -137,8 +137,7 @@ jobs:
       - name: Pip Install NumFOCUS nightly
         # NumFOCUS nightly wheels, contains numpy and pandas
         # TODO(gh-45): Re-add numpy
-        # TODO: Remove pandas version pin once https://github.com/pandas-dev/pandas/issues/55014 is fixed
-        run: python -m pip install --pre --upgrade --timeout=60 --extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple "pandas<2.1.0"
+        run: python -m pip install --pre --upgrade --timeout=60 --extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple
         if: matrix.numfocus_nightly
       - name: Install repository
         run: python -m pip install --no-build-isolation --no-deps --disable-pip-version-check -e .

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -8,7 +8,7 @@ dependencies:
   - msgpack-python>=0.5.2
   # Currently dask and numpy==1.16.0 clash
   - numpy!=1.15.0,!=1.16.0
-  - pandas>=0.23.0,!=1.0.0,<2.1.0
+  - pandas>=0.23.0,!=1.0.0
   - pyarrow>=4
   - simplejson
   - minimalkv

--- a/docs/guide/getting_started.rst
+++ b/docs/guide/getting_started.rst
@@ -191,6 +191,7 @@ use :func:`~plateau.io.eager.read_table`. This method returns the complete
 table of the dataset as a pandas DataFrame.
 
 .. ipython:: python
+    :okwarning:
 
     from plateau.api.dataset import read_table
 
@@ -230,6 +231,7 @@ function but returns a collection of ``dask.delayed`` objects.
     How this works is a complex topic, see :ref:`efficient_querying`.
 
     .. ipython:: python
+        :okwarning:
 
         read_table("a_unique_dataset_identifier", store_url, predicates=[[("A", "<", 2.5)]])
 

--- a/docs/guide/mutating_datasets.rst
+++ b/docs/guide/mutating_datasets.rst
@@ -90,6 +90,7 @@ If we read the data again, we can see that the ``another_df`` has been appended 
 previous contents.
 
 .. ipython:: python
+    :okwarning:
 
     from plateau.api.dataset import read_table
 
@@ -190,7 +191,7 @@ with one update:
 
     modified_df = another_df.copy()
     # set column E to have value 'train' for all rows in this dataframe
-    modified_df.B = pd.Timestamp("20130103")
+    modified_df.B = pd.Timestamp("20130103").as_unit("ns")
 
     dm = update_dataset_from_dataframes(
         [
@@ -200,7 +201,7 @@ with one update:
         dataset_uuid=dm.uuid,
         partition_on="B",  # don't forget to specify the partitioning column
         delete_scope=[
-            {"B": pd.Timestamp("2013-01-03")}
+            {"B": pd.Timestamp("2013-01-03").as_unit("ns")}
         ],  # specify the partition to be deleted
     )
     sorted(dm.partitions.keys())

--- a/docs/spec/indexing.rst
+++ b/docs/spec/indexing.rst
@@ -22,6 +22,7 @@ Users typically do not interact with indices directly since querying a dataset w
 All indices implement :class:`~plateau.core.index.IndexBase` which allows the user to interact with the indices in some useful ways.
 
 .. ipython:: python
+    :okwarning:
 
     from plateau.api.dataset import IndexBase
 

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   # Currently dask and numpy==1.16.0 clash
   # TODO: add support for numpy>=1.23
   - numpy!=1.15.0,!=1.16.0
-  - pandas>=0.23.0,!=1.0.0,<2.1.0
+  - pandas>=0.23.0,!=1.0.0
   - pyarrow>=4
   - simplejson
   - minimalkv>=1.4.2

--- a/plateau/io/testing/read.py
+++ b/plateau/io/testing/read.py
@@ -589,8 +589,8 @@ def test_datetime_predicate_with_dates_as_object(
         b, c = b_c
         df = pd.DataFrame({"a": [1, 1], "b": [b, b], "c": c, "d": [b, b + 1]})
 
-        # Account pandas 2.0 change in behaviour in which datetime columns have
-        # their units set to [us] rather than [ns].
+        # Account for pandas 2.1 change in behaviour in which datetime.datetime
+        # columns have their units set to [us] rather than [ns].
         return (
             df.astype({"c": "datetime64[ns]"})
             if df["c"].dtype == "datetime64[us]"

--- a/plateau/io/testing/read.py
+++ b/plateau/io/testing/read.py
@@ -588,7 +588,14 @@ def test_datetime_predicate_with_dates_as_object(
     def _f(b_c):
         b, c = b_c
         df = pd.DataFrame({"a": [1, 1], "b": [b, b], "c": c, "d": [b, b + 1]})
-        return df
+
+        # Account pandas 2.0 change in behaviour in which datetime columns have
+        # their units set to [us] rather than [ns].
+        return (
+            df.astype({"c": "datetime64[ns]"})
+            if df["c"].dtype == "datetime64[us]"
+            else df
+        )
 
     in_partitions = [_f([1, datetype(2000, 1, 1)])]
     dataset_uuid = "partitioned_uuid"

--- a/plateau/io_components/metapartition.py
+++ b/plateau/io_components/metapartition.py
@@ -775,7 +775,7 @@ class MetaPartition(Iterable):
                 value = dtype(value)
             elif isinstance(dtype, np.dtype):
                 if is_datetime64_any_dtype(dtype):
-                    # Coerce all datetime64 units to nanoseconds maintain consistent behaviour
+                    # Coerce all datetime64 units to nanoseconds to maintain consistency with serializers.
                     value = pd.Timestamp(value).as_unit("ns")
                 else:
                     value = dtype.type(value)

--- a/plateau/io_components/metapartition.py
+++ b/plateau/io_components/metapartition.py
@@ -26,6 +26,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 from minimalkv import KeyValueStore
+from pandas.api.types import is_datetime64_any_dtype
 
 from plateau.core import naming
 from plateau.core.common_metadata import (
@@ -773,8 +774,9 @@ class MetaPartition(Iterable):
             if isinstance(dtype, type):
                 value = dtype(value)
             elif isinstance(dtype, np.dtype):
-                if dtype == np.dtype("datetime64[ns]"):
-                    value = pd.Timestamp(value)
+                if is_datetime64_any_dtype(dtype):
+                    # Coerce all datetime64 units to nanoseconds maintain consistent behaviour
+                    value = pd.Timestamp(value).as_unit("ns")
                 else:
                     value = dtype.type(value)
             else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
     msgpack>=0.5.2
     # Currently dask and numpy==1.16.0 clash
     numpy!=1.15.0,!=1.16.0
-    pandas>=0.23.0,!=1.0.0,<2.1.0
+    pandas>=0.23.0,!=1.0.0
     pyarrow>=4
     simplejson
     minimalkv>=1.4.2

--- a/tests/io_components/test_dataset.py
+++ b/tests/io_components/test_dataset.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 
 import pandas as pd
 import pandas.testing as pdt
-from packaging.version import Version
 
 from plateau.core.dataset import DatasetMetadata
 from plateau.core.index import ExplicitSecondaryIndex
@@ -103,10 +102,7 @@ def test_dataset_get_indices_as_dataframe_predicates():
         columns=["l_external_code"],
         predicates=[[("l_external_code", "==", "1"), ("p_external_code", "==", "3")]],
     )
-    if Version(pd.__version__) < Version("2.0.0.dev0"):
-        empty_index = pd.Index([], name="partition")
-    else:
-        empty_index = pd.Index([], name="partition", dtype="int64")
+    empty_index = pd.Index([], name="partition")
     expected = pd.DataFrame(columns=["l_external_code"], index=empty_index)
     pdt.assert_frame_equal(result, expected)
 
@@ -120,10 +116,7 @@ def test_dataset_get_indices_as_dataframe_no_index(dataset):
 def test_dataset_get_indices_as_dataframe_with_index(dataset_with_index, store_session):
     assert not dataset_with_index.primary_indices_loaded
     df = dataset_with_index.get_indices_as_dataframe()
-    if Version(pd.__version__) < Version("2.0.0.dev0"):
-        empty_index = pd.Index([], name="partition")
-    else:
-        empty_index = pd.Index([], name="partition", dtype="int64")
+    empty_index = pd.Index([], name="partition")
     pdt.assert_frame_equal(
         df,
         pd.DataFrame(columns=["L", "P"], index=empty_index).astype(


### PR DESCRIPTION
Removes Pandas less than 2.1.0 pin.

Pandas was pinned due to a change in the way `datetime.datetime` types are inferred by the `DataFrame` constructor. Previously, `datetime` dtypes were inferred as `datetime64[ns]`, but since `2.1.0` they have been inferred as `datetime64[us]`. [This issue](https://github.com/pandas-dev/pandas/issues/55014) implied that the change was a bug, however, after speaking with some of the maintainers, it is clear that this is not the case. This can be seen in [this comment](https://github.com/pandas-dev/pandas/issues/55014#issuecomment-1764819726) and the [original PR](https://github.com/pandas-dev/pandas/pull/52212).

Therefore, some changes are required to the way we deal with `datetime64` dtypes.

- [x] Closes #92