### PR TITLE
Coerce timestamp units in metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+Plateau 4.2.1 (2023-10-31)
+==========================
+
+* Add support for pandas 2.1
+* Fix a bug to do with timestamp dtype conversion
+* Add timestamp unit coercion as Plateau currently only supports nanosecond units on timestamps
+
 Plateau 4.2.0 (2023-10-10)
 ==========================
 


### PR DESCRIPTION
Currently, `plateau` only supports timestamps with nanosecond resolution.

When saving to parquet files, all timestamp units are coerced (by arrow) to microsecond resolution, and then coerced back (by `plateau`) to nanoseconds after being loaded. This PR ensures that the conversion process does not cause an error by similarly coercing the units of timestamps in table schemas.

This PR also prepares the release of `plateau` 4.2.1.

- [x] Changelog entry
