### PR TITLE
CI Fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           - numfocus_nightly: true
             os: "ubuntu-latest"
             pandas: ""
-            pyarrow: "4.0.1"
+            pyarrow: "nightly"
             python: "3.10"
           - numfocus_nightly: false
             os: "ubuntu-latest"
@@ -134,8 +134,7 @@ jobs:
           create-args: >-
             python=${{ matrix.python }}
       - name: Install Pyarrow (non-nightly)
-        # Don't pin python as older versions of pyarrow require older versions of python
-        run: micromamba install -y --no-py-pin pyarrow==${{ matrix.pyarrow }}
+        run: micromamba install -y pyarrow==${{ matrix.pyarrow }}
         if: matrix.pyarrow != 'nightly' && matrix.pandas == ''
       - name: Install Pyarrow (nightly)
         # Install both arrow-cpp and pyarrow to make sure that we have the


### PR DESCRIPTION
CI failures are caused by the following package incompatibilities.

1. https://github.com/dask/dask/issues/11038 Some versions of dask are incompatible with python 3.11.9. We were accidentally upgrading to this python version due to a `--no-py-pin` I added that we no longer need. Removing this fixes the issue, but this is not a true fix - perhaps we should pin dask to avoid the problematic versions (I don't know which versions are affected, only that the fix went into [2024.4.1](https://github.com/dask/dask/pull/11035), and has been back-ported to [2024.2.1](https://github.com/conda-forge/dask-core-feedstock/pull/202)).
2. Pyarrow uses `pandas.core.internals.DatetimeTZBlock`, which will be removed in the next major release, and is [already gone](https://github.com/pandas-dev/pandas/pull/58467/) from the nightly builds. This is already handled in newer versions of pyarrow by [checking the pandas API version](https://github.com/apache/arrow/blob/f6127a6d18af12ce18a0b8b1eac02346721cc399/python/pyarrow/pandas_compat.py#L718C1-L727C53), but causes failures for older versions of pyarrow. Perhaps this could be fixed by patching the [repodata for pyarrow](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/patch_yaml/pyarrow.yaml), but I'm uncertain whether this can be done for an optional dependency like pandas. For now, I've fixed this by testing the pyarrow and pandas nightly builds together, but an actual solution might be to drop support for older version of pyarrow when pandas 3 is released.