### PR TITLE
Fix datetime utcnow deprecation

### DIFF
--- a/plateau/core/_time.py
+++ b/plateau/core/_time.py
@@ -22,6 +22,6 @@ def datetime_utcnow():
 
     Same as datetime.datetime.utcnow
     """
-    if sys.version_info <= (3, 10):
+    if sys.version_info < (3, 11):
         return datetime.datetime.utcnow()
     return datetime.datetime.now(datetime.UTC)

--- a/plateau/core/_time.py
+++ b/plateau/core/_time.py
@@ -6,6 +6,7 @@ to fake certain fixed times.
 """
 
 import datetime
+import sys
 
 
 def datetime_now():
@@ -21,4 +22,6 @@ def datetime_utcnow():
 
     Same as datetime.datetime.utcnow
     """
+    if sys.version_info <= (3, 10):
+        return datetime.datetime.utcnow()
     return datetime.datetime.now(datetime.UTC)

--- a/plateau/core/_time.py
+++ b/plateau/core/_time.py
@@ -21,4 +21,4 @@ def datetime_utcnow():
 
     Same as datetime.datetime.utcnow
     """
-    return datetime.datetime.utcnow()
+    return datetime.datetime.now(datetime.UTC)


### PR DESCRIPTION
This is deprecated since 3.12 but should already work on older version