### PR TITLE
Handle string dtypes in schema compatibility checks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,9 +2,12 @@
 Changelog
 =========
 
-Next release
-============
+Plateau 4.6.0 (2025-08-11)
+==========================
 
+* Schema normalization for pandas 3.x `str` dtype. String fields are considered
+  compatible if they are using the same NA value but pandas storage backend is
+  being ignored.
 * Support for pyarrow 21.0.0
 * Drop support for pyarrow 15.0.2, 16.1.0 and 17.0.0
 

--- a/plateau/core/common_metadata.py
+++ b/plateau/core/common_metadata.py
@@ -319,8 +319,7 @@ def normalize_type(
         )
         return pa.list_(t_pa2), f"list[{t_pd2}]", "object", None
     elif pa.types.is_dictionary(t_pa):
-        # downcast to dictionary content, `t_pd` is useless in that case
-        return normalize_type(t_pa.value_type, t_np, t_np, None)
+        return normalize_type(t_pa.value_type, t_pd, t_np, None)
     elif pa.types.is_string(t_pa) or pa.types.is_large_string(t_pa):
         # Pyarrow only supports reading back
         #
@@ -335,7 +334,11 @@ def normalize_type(
 
         # pandas also supports mixed types but those are rare and must be
         # constructed explicitly
-        if t_np == "str":
+        if t_pd == "categorical":
+            # We loose the information of the nullable type since the t_np type
+            # is set to the dtype of the codes but not the categories.
+            return pa.large_string(), "object", "str", None
+        elif t_np == "str":
             return pa.large_string(), "object", "str", None
         elif t_np == "string":
             return pa.string(), "unicode", "string", None

--- a/plateau/io/testing/read.py
+++ b/plateau/io/testing/read.py
@@ -36,7 +36,7 @@ import pandas.testing as pdt
 import pytest
 from minimalkv import get_store_from_url
 
-from plateau.core._compat import pandas_infer_string
+from plateau.core._compat import PANDAS_3, pandas_infer_string
 from plateau.io.eager import store_dataframes_as_dataset
 from plateau.io.iter import store_dataframes_as_dataset__iter
 from plateau.io_components.metapartition import SINGLE_TABLE, MetaPartition
@@ -648,8 +648,14 @@ def test_binary_column_metadata(store_factory, bound_load_dataframes):
     assert set(df.columns.map(type)) == {str}
 
 
-def test_extensiondtype_roundtrip(store_factory, bound_load_dataframes):
-    df = pd.DataFrame({"str": pd.Series(["a", "b"], dtype="string")})
+def test_string_type_roundtrip(store_factory, bound_load_dataframes):
+    # Note: we're not actually roundtripping the string type since the loading
+    # type depends on the pandas version. Keeping the loading type aligned with
+    # what is typically initialized by pandas by default is likely the best
+    # option
+    df = pd.DataFrame(
+        {"str": pd.Series(["a", "b"], dtype="str" if PANDAS_3 else "string")}
+    )
 
     store_dataframes_as_dataset(
         dfs=[df], store=store_factory, dataset_uuid="dataset_uuid"


### PR DESCRIPTION
This establishes well defined semantics about how we deal with string data types. The behavior here is strongly motivated by how pyarrow is reading back data since it only preserves the NA value on roundtrip but not the storage backend (remember: pandas 3.X StringDtype allows the selection of both the storage backend and the na value).

The pandas dtype we will get back will be uniquely determined by the NA value and the returned dtype will properly align with `str` (`np.nan` as null) and `string` (`pd.NA` as null).
Similarly, plateau will take the provided string dtype and will project them to the appropriate "default" dtype similar to how pyarrow works. This means that an update with the same null value but different storage backends will be compatible and resolve while different NA values will be rejected regardless of storage backend.

The only exception to this rule are categorical values. It seems that pyarrow is dropping the pandas metadata that would be required to infer what kind of null value was used and is always assuming that it is a `str` dtype. We'll do the same. In practice, this doesn't matter at all since categories, by definition, cannot have a null.

<3 pandas strings