### PR TITLE
fix: Preserve ordered categorials

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,12 @@
 Changelog
 =========
 
-Plateau 4.6.2 (2025-08-XX)
+Plateau 4.7.0 (2026-06-XX)
+==========================
+
+* ``align_categories`` now preserves ``ordered=True`` when all partitions share an identical ordered category sequence; otherwise it warns and falls back to an unordered categorical.
+
+Plateau 4.6.2 (2025-09-22)
 ==========================
 
 * Add support for `not in` predicate operation.

--- a/plateau/io/eager.py
+++ b/plateau/io/eager.py
@@ -261,16 +261,28 @@ def read_table(
         factory=ds_factory,
     )
 
+    # require meta 4 otherwise, can't construct types/columns
     empty_df = empty_dataframe_from_schema(
         schema=ds_factory.schema,
         columns=columns,
     )
     if categoricals:
         empty_df = empty_df.astype(dict.fromkeys(categoricals, "category"))
-    dfs = list(partitions) + [empty_df]
-    # require meta 4 otherwise, can't construct types/columns
-    if categoricals:
+
+    dfs = list(partitions)
+    if categoricals and dfs:
         dfs = align_categories(dfs, categoricals)
+        # Match the empty placeholder's categorical dtypes to the aligned
+        # partitions so concat keeps the partitions' (possibly ordered)
+        # categorical type rather than downcasting to object.
+        aligned_cat_dtypes = {
+            col: dfs[0][col].dtype
+            for col in categoricals
+            if isinstance(dfs[0][col].dtype, pd.CategoricalDtype)
+        }
+        if aligned_cat_dtypes:
+            empty_df = empty_df.astype(aligned_cat_dtypes)
+    dfs.append(empty_df)
     df = pd.concat(dfs, ignore_index=True, sort=False)
 
     # ensure column order

--- a/plateau/io/testing/read.py
+++ b/plateau/io/testing/read.py
@@ -686,3 +686,43 @@ def test_non_default_table_name_roundtrip(store_factory, bound_load_dataframes):
         result_dfs = result
     result_df = pd.concat(result_dfs).reset_index(drop=True)
     pdt.assert_frame_equal(df, result_df)
+
+
+def _assert_ordered_categorical_roundtrip(store_factory, bound_load_dataframes):
+    ordered_dtype = pd.CategoricalDtype(
+        categories=["low", "medium", "high"], ordered=True
+    )
+    df_0 = pd.DataFrame(
+        {
+            "id": [0, 1],
+            "priority": pd.Categorical(["low", "high"], dtype=ordered_dtype),
+        }
+    )
+    df_1 = pd.DataFrame(
+        {
+            "id": [2, 3],
+            "priority": pd.Categorical(["medium", "low"], dtype=ordered_dtype),
+        }
+    )
+    store_dataframes_as_dataset(
+        dfs=[df_0, df_1], store=store_factory, dataset_uuid="dataset_uuid"
+    )
+
+    result = bound_load_dataframes(
+        dataset_uuid="dataset_uuid",
+        store=store_factory,
+        categoricals=["priority"],
+    )
+
+    probe = result[0]
+    if isinstance(probe, MetaPartition):
+        result_dfs = [mp.data for mp in result]
+    else:
+        result_dfs = result
+    result_df = pd.concat(result_dfs).sort_values("id").reset_index(drop=True)
+    expected_df = pd.concat([df_0, df_1]).reset_index(drop=True)
+    pdt.assert_frame_equal(result_df, expected_df)
+
+
+def test_ordered_categorical_roundtrip(store_factory, bound_load_dataframes):
+    _assert_ordered_categorical_roundtrip(store_factory, bound_load_dataframes)

--- a/plateau/io_components/utils.py
+++ b/plateau/io_components/utils.py
@@ -3,6 +3,7 @@
 import collections
 import inspect
 import logging
+import warnings
 from collections.abc import Iterable
 from typing import Literal, cast, overload
 
@@ -318,6 +319,8 @@ def align_categories(dfs, categoricals):
         position_largest_df = None
         categories = set()
         largest_df_categories = set()
+        ordered_sequences: list[tuple] = []
+        unordered_seen = False
         for ix, df in enumerate(dfs):
             ser = df[column]
             if not isinstance(ser.dtype, pd.CategoricalDtype):
@@ -329,6 +332,10 @@ def align_categories(dfs, categoricals):
                 )
             else:
                 cats = ser.cat.categories
+                if ser.cat.ordered:
+                    ordered_sequences.append(tuple(cats))
+                else:
+                    unordered_seen = True
                 length = len(df)
                 if position_largest_df is None or length > position_largest_df[0]:
                     position_largest_df = (length, ix)
@@ -336,12 +343,39 @@ def align_categories(dfs, categoricals):
                     largest_df_categories = cats
             categories.update(cats)
 
+        unique_ordered_sequences = set(ordered_sequences)
+        all_ordered_agree = bool(
+            ordered_sequences
+            and not unordered_seen
+            and len(unique_ordered_sequences) == 1
+        )
+        if ordered_sequences and not all_ordered_agree:
+            # Refusing to align would force a full rewrite of the dataset,
+            # which is impractical for large datasets that have evolved over
+            # time. Fall back to an unordered categorical and warn so the
+            # downgrade is visible.
+            if unordered_seen:
+                detail = "mixes ordered and unordered partitions"
+            else:
+                detail = (
+                    f"has ordered partitions with differing category "
+                    f"sequences ({sorted(unique_ordered_sequences)})"
+                )
+            warnings.warn(
+                f"Column {column!r} {detail}; falling back to an "
+                "unordered categorical.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         # use the categories of the largest DF as a baseline to avoid having
         # to rewrite its codes. Append the remainder and sort it for reproducibility
         categories_lst = list(largest_df_categories) + sorted(
             set(categories) - set(largest_df_categories)
         )
-        cat_dtype = pd.api.types.CategoricalDtype(categories_lst, ordered=False)
+        cat_dtype = pd.api.types.CategoricalDtype(
+            categories_lst, ordered=all_ordered_agree
+        )
         col_dtype[column] = cat_dtype
 
     return_dfs = []

--- a/tests/io/dask/dataframe/test_read.py
+++ b/tests/io/dask/dataframe/test_read.py
@@ -301,6 +301,22 @@ def test_dask_index_on_non_string_raises(store_factory):
         )
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "read_dataset_as_ddf does not yet propagate ordered=True through the "
+        "dask meta. align_categories now preserves the flag, but the dask "
+        "frontend builds its meta independently."
+    ),
+)
+def test_ordered_categorical_roundtrip(store_factory):  # noqa: F811
+    from plateau.io.testing.read import _assert_ordered_categorical_roundtrip
+
+    _assert_ordered_categorical_roundtrip(
+        store_factory=store_factory, bound_load_dataframes=_read_as_ddf
+    )
+
+
 def test_dask_dispatch_by_raises_if_index_on_not_none(store_factory):
     dataset_uuid = "dataset_uuid"
     colA = "ColumnA"

--- a/tests/io/eager/test_read.py
+++ b/tests/io/eager/test_read.py
@@ -172,3 +172,35 @@ def test_read_or_predicates(store_factory, partition_on):
 
     pd.testing.assert_frame_equal(df1, df2)
     pd.testing.assert_frame_equal(expected, df2)
+
+
+def test_read_table_ordered_categorical_disagreeing_partitions_warns(store_factory):
+    # Partitions with disagreeing ordered category sequences cannot be
+    # unambiguously aligned; read_table warns and falls back to an unordered
+    # categorical rather than refusing to load (which would force a full
+    # rewrite of the dataset).
+    df_0 = pd.DataFrame(
+        {
+            "id": [0],
+            "priority": pd.Categorical(["a"], categories=["a", "b"], ordered=True),
+        }
+    )
+    df_1 = pd.DataFrame(
+        {
+            "id": [1],
+            "priority": pd.Categorical(["b"], categories=["b", "a"], ordered=True),
+        }
+    )
+    store_dataframes_as_dataset(
+        dfs=[df_0, df_1], store=store_factory, dataset_uuid="dataset_uuid"
+    )
+
+    with pytest.warns(UserWarning, match="differing category sequences"):
+        df = read_table(
+            dataset_uuid="dataset_uuid",
+            store=store_factory,
+            categoricals=["priority"],
+        )
+
+    assert df["priority"].dtype.name == "category"
+    assert not df["priority"].cat.ordered

--- a/tests/io_components/test_utils.py
+++ b/tests/io_components/test_utils.py
@@ -216,6 +216,97 @@ def test_align_categories_with_missings():
     pdt.assert_frame_equal(out[1], expected_1)
 
 
+def test_align_categories_preserves_ordered():
+    # All partitions share an identical ordered dtype: result is ordered.
+    ordered_dtype = pd.CategoricalDtype(
+        categories=["low", "medium", "high"], ordered=True
+    )
+    df_0 = pd.DataFrame(
+        {"priority": pd.Categorical(["low", "high"], dtype=ordered_dtype)}
+    )
+    df_1 = pd.DataFrame(
+        {"priority": pd.Categorical(["medium", "low"], dtype=ordered_dtype)}
+    )
+
+    out = align_categories([df_0, df_1], ["priority"])
+
+    for df in out:
+        assert df["priority"].dtype == ordered_dtype
+
+
+def test_align_categories_unordered_stays_unordered():
+    df_0 = pd.DataFrame({"col": pd.Categorical(["a", "b"])})
+    df_1 = pd.DataFrame({"col": pd.Categorical(["b", "c"])})
+
+    out = align_categories([df_0, df_1], ["col"])
+
+    for df in out:
+        assert not df["col"].cat.ordered
+
+
+def test_align_categories_warns_on_mixed_ordered_and_unordered():
+    df_ordered = pd.DataFrame(
+        {
+            "priority": pd.Categorical(
+                ["low", "high"],
+                categories=["low", "medium", "high"],
+                ordered=True,
+            )
+        }
+    )
+    df_unordered = pd.DataFrame({"priority": pd.Categorical(["medium"])})
+
+    with pytest.warns(UserWarning, match="mixes ordered and unordered"):
+        out = align_categories([df_ordered, df_unordered], ["priority"])
+
+    for df in out:
+        assert not df["priority"].cat.ordered
+
+
+def test_align_categories_warns_on_differing_ordered_sequences():
+    # Same category set, different ordering — fall back to unordered with a
+    # warning rather than refusing to load.
+    df_0 = pd.DataFrame(
+        {"col": pd.Categorical(["a"], categories=["a", "b"], ordered=True)}
+    )
+    df_1 = pd.DataFrame(
+        {"col": pd.Categorical(["b"], categories=["b", "a"], ordered=True)}
+    )
+
+    with pytest.warns(UserWarning, match="differing category sequences"):
+        out = align_categories([df_0, df_1], ["col"])
+
+    for df in out:
+        assert not df["col"].cat.ordered
+
+
+def test_align_categories_warns_on_extending_ordered_categories():
+    # A prefix relationship also triggers a fallback; users typically hit this
+    # when a dataset's categories were extended over time.
+    df_0 = pd.DataFrame(
+        {
+            "priority": pd.Categorical(
+                ["low"], categories=["low", "medium", "high"], ordered=True
+            )
+        }
+    )
+    df_1 = pd.DataFrame(
+        {
+            "priority": pd.Categorical(
+                ["urgent"],
+                categories=["low", "medium", "high", "urgent"],
+                ordered=True,
+            )
+        }
+    )
+
+    with pytest.warns(UserWarning, match="differing category sequences"):
+        out = align_categories([df_0, df_1], ["priority"])
+
+    for df in out:
+        assert not df["priority"].cat.ordered
+
+
 def test_sort_categorical():
     values = ["f", "a", "b", "z", "e"]
     categories = ["e", "z", "b", "a", "f"]


### PR DESCRIPTION
Plateau's parquet files preserve the ordered flag on categorical columns, but `align_categories` was hardcoding `ordered=False` when unifying partitions, silently downgrading ordered categoricals on read.

Example:
```python
import pandas as pd
from minimalkv import get_store_from_url

from plateau.io.eager import read_table, store_dataframes_as_dataset

store = get_store_from_url("hfs:///tmp/plateau_demo")

df = pd.DataFrame(
    {
        "priority": pd.Categorical(
            ["low", "high"],
            categories=["low", "medium", "high"],
            ordered=True,
        ),
    }
)
store_dataframes_as_dataset(dfs=[df], store=store, dataset_uuid="demo")

out = read_table(dataset_uuid="demo", store=store, categoricals=["priority"])
print(out["priority"].cat.ordered) 
# BEFORE: false
# NOW: true
```

This PR makes `align_categories` preserve `ordered=True` when all partitions agree, and warn-and-fall-back when they don't.

Note that `plateau.io.iter.read_dataset_as_dataframes__iterator` was already preserving ordered categoricals. It was just the `align_categories` step that removed the ordering.
