### PR TITLE
fix: Also preserve ordered categoricals for dask backend

### DIFF
--- a/plateau/core/common_metadata.py
+++ b/plateau/core/common_metadata.py
@@ -320,7 +320,7 @@ def normalize_type(
     - all list value types will be normalized (e.g. ``list[int16]`` to ``list[int64]``, ``list[list[uint8]]`` to
       ``list[list[uint64]]``)
     - all dict value types will be normalized (e.g. ``dictionary<values=float32, indices=int16, ordered=0>`` to
-      ``float64``)
+      ``float64``); the ``ordered`` flag is preserved in the returned metadata.
 
     Parameters
     ----------
@@ -346,7 +346,14 @@ def normalize_type(
         )
         return pa.list_(t_pa2), f"list[{t_pd2}]", "object", None
     elif pa.types.is_dictionary(t_pa):
-        return normalize_type(t_pa.value_type, t_pd, t_np, None)
+        # Strip the dictionary type itself (we always materialise categoricals
+        # at read time based on the user's `categoricals` argument) but keep
+        # the ``ordered`` flag in the per-column pandas metadata so downstream
+        # readers can reconstruct an ordered ``CategoricalDtype``.
+        t_pa2, t_pd2, t_np2, _metadata = normalize_type(
+            t_pa.value_type, t_pd, t_np, None
+        )
+        return t_pa2, t_pd2, t_np2, {"ordered": bool(t_pa.ordered)}
     elif pa.types.is_string(t_pa) or pa.types.is_large_string(t_pa):
         # Pyarrow only supports reading back
         #

--- a/plateau/io/dask/dataframe.py
+++ b/plateau/io/dask/dataframe.py
@@ -179,7 +179,15 @@ def _get_dask_meta_for_dataset(ds_factory, columns, categoricals, dates_as_objec
     )
 
     if categoricals:
-        meta = meta.astype(dict.fromkeys(categoricals, "category"))
+        # Datasets written before ordered metadata was tracked have no
+        # `ordered` flag in their pandas metadata and load as unordered.
+        ordered_columns = _ordered_categorical_columns(table_schema, categoricals)
+        meta = meta.astype(
+            {
+                c: pd.CategoricalDtype([], ordered=c in ordered_columns)
+                for c in categoricals
+            }
+        )
         meta = dd.utils.clear_known_categories(meta, categoricals)
 
     categoricals_from_index = _maybe_get_categoricals_from_index(
@@ -188,6 +196,28 @@ def _get_dask_meta_for_dataset(ds_factory, columns, categoricals, dates_as_objec
     if categoricals_from_index:
         meta = meta.astype(categoricals_from_index)
     return meta
+
+
+def _ordered_categorical_columns(schema, categoricals):
+    """Return the subset of ``categoricals`` recorded as ``ordered=True`` in
+    the dataset's pandas schema metadata.
+
+    Datasets written by plateau versions that did not record this metadata
+    fall through and are loaded as unordered categoricals.
+    """
+    pandas_metadata = schema.pandas_metadata
+    if not pandas_metadata:
+        return set()
+    requested = set(categoricals)
+    ordered = set()
+    for cmd in pandas_metadata["columns"]:
+        name = cmd.get("name")
+        if name not in requested:
+            continue
+        col_meta = cmd.get("metadata") or {}
+        if col_meta.get("ordered"):
+            ordered.add(name)
+    return ordered
 
 
 def _shuffle_docs(func):

--- a/tests/core/test_common_metadata.py
+++ b/tests/core/test_common_metadata.py
@@ -143,6 +143,27 @@ def test_strip_categories():
     assert not pa.types.is_dictionary(meta[0].type)
 
 
+@pytest.mark.parametrize("ordered", [True, False])
+def test_make_meta_records_ordered_flag(ordered):
+    # The dictionary type itself is stripped, but the per-column pandas
+    # metadata retains the ordered flag so downstream readers can reconstruct
+    # an ordered ``CategoricalDtype``.
+    input_df = pd.DataFrame(
+        {
+            "priority": pd.Categorical(
+                ["low", "high"],
+                categories=["low", "medium", "high"],
+                ordered=ordered,
+            )
+        }
+    )
+    meta = make_meta(input_df, origin="input_df")
+
+    columns = meta.pandas_metadata["columns"]
+    (priority_meta,) = (c for c in columns if c.get("name") == "priority")
+    assert priority_meta["metadata"] == {"ordered": ordered}
+
+
 def test_reorder(df_all_types):
     df2 = df_all_types.copy()
     df2 = df2.reindex(reversed(df_all_types.columns), axis=1)

--- a/tests/io/dask/dataframe/test_read.py
+++ b/tests/io/dask/dataframe/test_read.py
@@ -5,6 +5,7 @@ import dask
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 from dask.dataframe.utils import assert_eq as assert_dask_eq
 from packaging import version
@@ -44,7 +45,8 @@ def _read_as_ddf(
         table=table,
         **kwargs,
     )
-    if categoricals:
+    # The asserts below only apply to the canonical P/L test fixture.
+    if categoricals and "P" in ddf._meta.columns:
         assert ddf._meta.dtypes["P"] == pd.api.types.CategoricalDtype(
             categories=["__UNKNOWN_CATEGORIES__"], ordered=False
         )
@@ -65,7 +67,10 @@ def _read_as_ddf(
     def extract_dataframe(ix):
         df = ddf.iloc[[ix]].copy()
         for col in df.columns:
-            if isinstance(df[col].dtype, pd.CategoricalDtype):
+            if (
+                isinstance(df[col].dtype, pd.CategoricalDtype)
+                and not df[col].cat.ordered
+            ):
                 df[col] = df[col].cat.remove_unused_categories()
         return df.reset_index(drop=True)
 
@@ -301,14 +306,6 @@ def test_dask_index_on_non_string_raises(store_factory):
         )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "read_dataset_as_ddf does not yet propagate ordered=True through the "
-        "dask meta. align_categories now preserves the flag, but the dask "
-        "frontend builds its meta independently."
-    ),
-)
 def test_ordered_categorical_roundtrip(store_factory):  # noqa: F811
     from plateau.io.testing.read import _assert_ordered_categorical_roundtrip
 
@@ -336,3 +333,29 @@ def test_dask_dispatch_by_raises_if_index_on_not_none(store_factory):
             dask_index_on=colA,
             dispatch_by=[colA],
         )
+
+
+@pytest.mark.parametrize(
+    "df, expected",
+    [
+        (
+            pd.DataFrame({"p": pd.Categorical(["a"], ordered=True)}),
+            {"p"},
+        ),
+        (
+            pd.DataFrame({"p": pd.Categorical(["a"], ordered=False)}),
+            set(),
+        ),
+        (
+            # Schema without pandas metadata: nothing recorded as ordered.
+            pa.schema([pa.field("p", pa.string())]),
+            set(),
+        ),
+    ],
+)
+def test_ordered_categorical_columns(df, expected):
+    from plateau.core.common_metadata import make_meta
+    from plateau.io.dask.dataframe import _ordered_categorical_columns
+
+    schema = make_meta(df, origin="test") if isinstance(df, pd.DataFrame) else df
+    assert _ordered_categorical_columns(schema, ["p"]) == expected


### PR DESCRIPTION
Part 2 of #361.

This also preserves ordered categoricals for the dask backend.